### PR TITLE
Unnecessary libs in artifact

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -28,5 +28,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'junit:junit:4.12'
+    testCompile 'junit:junit:4.12'
 }


### PR DESCRIPTION
@brianPlummer   Definitely don't need junit. Do you need app compat? Noticed both were in final aar

also run it before merging. I'm pr-ing from phone 